### PR TITLE
Fix casing in string extension

### DIFF
--- a/src/Atc.Kusto/Extensions/Internal/StringExtensions.cs
+++ b/src/Atc.Kusto/Extensions/Internal/StringExtensions.cs
@@ -13,7 +13,7 @@ internal static partial class StringExtensions
     /// <returns>A <see cref="Regex"/> instance that can be used to replace non-alphanumeric characters.</returns>
 
     [GeneratedRegex("[^a-zA-Z0-9]", RegexOptions.Singleline, 1000)]
-    private static partial Regex AlphaNumericRegex();
+    private static partial Regex AlphanumericRegex();
 
     /// <summary>
     /// Removes all non-alphanumeric characters from the input string, leaving only letters and digits.
@@ -21,7 +21,7 @@ internal static partial class StringExtensions
     /// </summary>
     /// <param name="str">The input string to be filtered.</param>
     /// <returns>A new string containing only alphanumeric characters from the input string.</returns>
-    public static string ToAlphaNumeric(
+    public static string ToAlphanumeric(
         this string str)
-        => AlphaNumericRegex().Replace(str, string.Empty);
+        => AlphanumericRegex().Replace(str, string.Empty);
 }

--- a/src/Atc.Kusto/Handlers/Internal/ExistingPagedStoredQueryHandler.cs
+++ b/src/Atc.Kusto/Handlers/Internal/ExistingPagedStoredQueryHandler.cs
@@ -44,7 +44,7 @@ internal sealed class ExistingPagedStoredQueryHandler<T> : IScriptHandler<PagedR
             return null;
         }
 
-        var queryId = split[0].ToAlphaNumeric();
+        var queryId = split[0].ToAlphanumeric();
 
         if (!long.TryParse(split[1], GlobalizationConstants.EnglishCultureInfo, out var itemsReturned))
         {

--- a/src/Atc.Kusto/Providers/Internal/QueryIdProvider.cs
+++ b/src/Atc.Kusto/Providers/Internal/QueryIdProvider.cs
@@ -18,6 +18,6 @@ internal sealed class QueryIdProvider : IQueryIdProvider
 
         return string
             .Concat(queryType.Name, finalSessionId)
-            .ToAlphaNumeric();
+            .ToAlphanumeric();
     }
 }

--- a/test/Atc.Kusto.Tests/Extensions/Internal/StringExtensionsTests.cs
+++ b/test/Atc.Kusto.Tests/Extensions/Internal/StringExtensionsTests.cs
@@ -21,7 +21,7 @@ public sealed class StringExtensionsTests
         string expected)
     {
         // Arrange & Act
-        var actual = input.ToAlphaNumeric();
+        var actual = input.ToAlphanumeric();
 
         // Assert
         Assert.Equal(expected, actual);
@@ -34,7 +34,7 @@ public sealed class StringExtensionsTests
         var input = string.Empty;
 
         // Act
-        var actual = input.ToAlphaNumeric();
+        var actual = input.ToAlphanumeric();
 
         // Assert
         Assert.Equal(string.Empty, actual);


### PR DESCRIPTION
"Alphanumeric" is a one word and so "n" shouldn't be uppercased