### PR TITLE
Add DateOnly support for Kusto datetime deserialization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.212" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/sample/.editorconfig
+++ b/sample/.editorconfig
@@ -57,6 +57,7 @@ dotnet_diagnostic.CA1002.severity = none            # Change to use Collection, 
 dotnet_diagnostic.CA1062.severity = none            # In externally visible method validate parameter is non-null before using it (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062)
 dotnet_diagnostic.CA1303.severity = none            # Do not pass literals as localized parameters (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1303)
 dotnet_diagnostic.CA1848.severity = none            # For improved performance, use the LoggerMessage delegates (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1848)
+dotnet_diagnostic.CA1873.severity = none            #
 dotnet_diagnostic.CA2227.severity = none            # Change to be read-only by removing the property setter (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227)
 dotnet_diagnostic.CA2234.severity = none            # Uri instead of string (https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2234)
 

--- a/src/Atc.Kusto/Utilities/Internal/KustoDateOnlyJsonConverter.cs
+++ b/src/Atc.Kusto/Utilities/Internal/KustoDateOnlyJsonConverter.cs
@@ -1,0 +1,73 @@
+namespace Atc.Kusto.Utilities.Internal;
+
+/// <summary>
+/// Custom JSON converter for <see cref="DateOnly"/> values that handles Kusto's behavior of returning date values as full datetime strings.
+/// </summary>
+/// <remarks>
+/// Kusto has no native date-only type — functions like <c>startofday()</c> and <c>bin(Timestamp, 1d)</c> still return
+/// <c>datetime</c> values (e.g. <c>2024-01-15T00:00:00Z</c>). This converter allows C# result types to use
+/// <see cref="DateOnly"/> properties that correctly deserialize from both:
+/// <list type="bullet">
+///   <item><description>Date-only strings (e.g. <c>"2024-01-15"</c>)</description></item>
+///   <item><description>Full datetime strings (e.g. <c>"2024-01-15T00:00:00Z"</c>)</description></item>
+/// </list>
+/// </remarks>
+public sealed class KustoDateOnlyJsonConverter : JsonConverter<DateOnly>
+{
+    /// <summary>
+    /// Reads and converts a JSON string to a <see cref="DateOnly"/> value.
+    /// </summary>
+    /// <param name="reader">The reader to read JSON from.</param>
+    /// <param name="typeToConvert">The type to convert (will be <see cref="DateOnly"/>).</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The <see cref="DateOnly"/> value represented by the JSON string.</returns>
+    /// <exception cref="JsonException">Thrown when the string value is null or cannot be parsed as a date.</exception>
+    /// <remarks>
+    /// Handles two cases:
+    /// <list type="bullet">
+    ///   <item><description>Date-only strings (e.g. <c>"2024-01-15"</c>) — parsed directly via <see cref="DateOnly.TryParse(string?, IFormatProvider?, out DateOnly)"/></description></item>
+    ///   <item><description>Full datetime strings (e.g. <c>"2024-01-15T00:00:00Z"</c>) — parsed as <see cref="DateTimeOffset"/> and converted to <see cref="DateOnly"/></description></item>
+    /// </list>
+    /// </remarks>
+    public override DateOnly Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var value = reader.GetString()
+            ?? throw new JsonException(
+                $"Unable to convert null to {nameof(DateOnly)}.");
+
+        if (DateOnly.TryParse(value, CultureInfo.InvariantCulture, out var dateOnly))
+        {
+            return dateOnly;
+        }
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, out var dateTimeOffset))
+        {
+            return DateOnly.FromDateTime(dateTimeOffset.DateTime);
+        }
+
+        throw new JsonException(
+            $"Unable to convert \"{value}\" to {nameof(DateOnly)}.");
+    }
+
+    /// <summary>
+    /// Writes a <see cref="DateOnly"/> value as an ISO 8601 date string.
+    /// </summary>
+    /// <param name="writer">The writer to write JSON to.</param>
+    /// <param name="value">The <see cref="DateOnly"/> value to write.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <remarks>
+    /// Always writes the value as a date-only ISO 8601 string (e.g. <c>"2024-01-15"</c>).
+    /// </remarks>
+    public override void Write(
+        Utf8JsonWriter writer,
+        DateOnly value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteStringValue(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+}

--- a/src/Atc.Kusto/Utilities/Internal/KustoJsonSerializerOptions.cs
+++ b/src/Atc.Kusto/Utilities/Internal/KustoJsonSerializerOptions.cs
@@ -11,7 +11,7 @@ internal static class KustoJsonSerializerOptions
     /// </summary>
     public static JsonSerializerOptions Default { get; } = new()
     {
-        Converters = { new JsonStringEnumConverter(), new KustoBooleanJsonConverter() },
+        Converters = { new JsonStringEnumConverter(), new KustoBooleanJsonConverter(), new KustoDateOnlyJsonConverter() },
         PropertyNameCaseInsensitive = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
     };

--- a/test/Atc.Kusto.Tests/Extensions/DataReaderExtensionsTests.cs
+++ b/test/Atc.Kusto.Tests/Extensions/DataReaderExtensionsTests.cs
@@ -11,6 +11,10 @@ public sealed class DataReaderExtensionsTests
         bool IsActive,
         bool IsEnabled);
 
+    public record DateOnlyTestObject(
+        string Name,
+        DateOnly EventDate);
+
     [Theory, AutoNSubstituteData]
     public void ReadObjects_Will_Return_Objects_Read_From_DataReader(
         List<TestObject> data,
@@ -129,5 +133,40 @@ public sealed class DataReaderExtensionsTests
         Assert.Single(actual);
         Assert.Equal(expectedTrue, actual[0].IsActive);
         Assert.Equal(expectedFalse, actual[0].IsEnabled);
+    }
+
+    [Fact]
+    public void ReadObjects_Should_Convert_DateTime_To_DateOnly()
+    {
+        // Arrange - simulates Kusto returning datetime values for date-only columns (e.g. startofday())
+        var dataReader = Substitute.For<IDataReader>();
+
+        var fieldNames = new[] { "Name", "EventDate" };
+        var expectedDate = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        object[] rowValues = ["TestEvent", expectedDate];
+
+        dataReader.FieldCount
+            .Returns(2);
+
+        dataReader
+            .GetName(Arg.Any<int>())
+            .Returns(c => fieldNames[c.Arg<int>()]);
+
+        var readCount = 0;
+        dataReader
+            .Read()
+            .Returns(_ => readCount++ < 1);
+
+        dataReader
+            .GetValue(Arg.Any<int>())
+            .Returns(c => rowValues[c.Arg<int>()]);
+
+        // Act
+        var actual = dataReader.ReadObjects<DateOnlyTestObject>();
+
+        // Assert
+        Assert.Single(actual);
+        Assert.Equal("TestEvent", actual[0].Name);
+        Assert.Equal(new DateOnly(2024, 1, 15), actual[0].EventDate);
     }
 }

--- a/test/Atc.Kusto.Tests/Extensions/DataRowExtensionsTests.cs
+++ b/test/Atc.Kusto.Tests/Extensions/DataRowExtensionsTests.cs
@@ -38,6 +38,10 @@ public sealed class DataRowExtensionsTests
         int Count,
         object? DynamicData);
 
+    public record TestObjectWithDateOnly(
+        string Name,
+        DateOnly EventDate);
+
     [Fact]
     public void MapDataRow_Should_Return_Correct_Object()
     {
@@ -373,5 +377,27 @@ public sealed class DataRowExtensionsTests
         metadataElement.Value.GetArrayLength().Should().Be(2);
         metadataElement.Value[0].GetProperty("Id").GetInt32().Should().Be(1);
         metadataElement.Value[0].GetProperty("Value").GetString().Should().Be("First");
+    }
+
+    [Fact]
+    public void MapDataRow_Should_Handle_DateTime_To_DateOnly_Conversion()
+    {
+        // Arrange - simulates Kusto returning datetime for date-only values (e.g. startofday())
+        using var dataTable = new DataTable();
+        dataTable.Columns.Add("Name", typeof(string));
+        dataTable.Columns.Add("EventDate", typeof(DateTime));
+
+        var row = dataTable.NewRow();
+        row["Name"] = "TestEvent";
+        row["EventDate"] = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        dataTable.Rows.Add(row);
+
+        // Act
+        var actual = row.MapDataRow<TestObjectWithDateOnly>();
+
+        // Assert
+        actual.Should().NotBeNull();
+        actual!.Name.Should().Be("TestEvent");
+        actual.EventDate.Should().Be(new DateOnly(2024, 1, 15));
     }
 }

--- a/test/Atc.Kusto.Tests/Utilities/Internal/KustoDateOnlyJsonConverterTests.cs
+++ b/test/Atc.Kusto.Tests/Utilities/Internal/KustoDateOnlyJsonConverterTests.cs
@@ -1,0 +1,144 @@
+namespace Atc.Kusto.Tests.Utilities.Internal;
+
+public sealed class KustoDateOnlyJsonConverterTests
+{
+    [Theory]
+    [InlineData("2024-01-15", 2024, 1, 15)] // Date-only ISO 8601 string
+    [InlineData("2024-01-15T00:00:00Z", 2024, 1, 15)] // Kusto datetime from startofday(), bin()
+    [InlineData("2024-06-20T14:30:00+02:00", 2024, 6, 20)] // DateTime with timezone offset
+    public void Read_Should_Parse_Date_String(
+        string input,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay)
+    {
+        // Arrange
+        var json = Encoding.UTF8.GetBytes($"\"{input}\"");
+        var reader = new Utf8JsonReader(json);
+        reader.Read();
+        var converter = new KustoDateOnlyJsonConverter();
+
+        // Act
+        var result = converter.Read(ref reader, typeof(DateOnly), JsonSerializerOptions.Default);
+
+        // Assert
+        Assert.Equal(new DateOnly(expectedYear, expectedMonth, expectedDay), result);
+    }
+
+    [Fact]
+    public void Read_Should_Throw_JsonException_When_Value_Is_Null()
+    {
+        // Arrange
+        var json = "null"u8.ToArray();
+        var converter = new KustoDateOnlyJsonConverter();
+
+        // Act & Assert
+        var exception = Assert.Throws<JsonException>(() =>
+        {
+            var localReader = new Utf8JsonReader(json);
+            localReader.Read();
+            return converter.Read(ref localReader, typeof(DateOnly), JsonSerializerOptions.Default);
+        });
+
+        Assert.Contains("Unable to convert null", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("DateOnly", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Read_Should_Throw_JsonException_When_Value_Is_Not_A_Date()
+    {
+        // Arrange
+        var json = "\"not-a-date\""u8.ToArray();
+        var converter = new KustoDateOnlyJsonConverter();
+
+        // Act & Assert
+        var exception = Assert.Throws<JsonException>(() =>
+        {
+            var localReader = new Utf8JsonReader(json);
+            localReader.Read();
+            return converter.Read(ref localReader, typeof(DateOnly), JsonSerializerOptions.Default);
+        });
+
+        Assert.Contains("Unable to convert", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not-a-date", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("DateOnly", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Write_Should_Write_DateOnly_As_Iso8601_String()
+    {
+        // Arrange
+        var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        var converter = new KustoDateOnlyJsonConverter();
+
+        // Act
+        converter.Write(writer, new DateOnly(2024, 1, 15), JsonSerializerOptions.Default);
+        writer.Flush();
+
+        // Assert
+        var json = Encoding.UTF8.GetString(buffer.WrittenSpan);
+        Assert.Equal("\"2024-01-15\"", json);
+    }
+
+    [Fact]
+    public void Write_Should_Throw_ArgumentNullException_When_Writer_Is_Null()
+    {
+        // Arrange
+        var converter = new KustoDateOnlyJsonConverter();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(
+            () => converter.Write(writer: null!, new DateOnly(2024, 1, 15), JsonSerializerOptions.Default));
+    }
+
+    [Theory]
+    [InlineData("""{"EventDate":"2024-01-15T00:00:00Z","Count":42}""", 2024, 1, 15, 42)] // Kusto datetime string
+    [InlineData("""{"EventDate":"2024-03-20","Count":7}""", 2024, 3, 20, 7)] // Date-only string
+    public void Converter_Should_Work_With_JsonSerializer(
+        string json,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay,
+        int expectedCount)
+    {
+        // Arrange
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new KustoDateOnlyJsonConverter() },
+        };
+
+        // Act
+        var result = JsonSerializer.Deserialize<TestDateOnlyDto>(json, options);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new DateOnly(expectedYear, expectedMonth, expectedDay), result.EventDate);
+        Assert.Equal(expectedCount, result.Count);
+    }
+
+    [Fact]
+    public void Converter_Should_Serialize_DateOnly_As_Iso8601_String()
+    {
+        // Arrange
+        var dto = new TestDateOnlyDto { EventDate = new DateOnly(2024, 1, 15), Count = 10 };
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new KustoDateOnlyJsonConverter() },
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(dto, options);
+
+        // Assert
+        Assert.Contains("\"2024-01-15\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("T00:00:00", json, StringComparison.Ordinal);
+    }
+
+    private sealed record TestDateOnlyDto
+    {
+        public DateOnly EventDate { get; init; }
+
+        public int Count { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary

  - Add `KustoDateOnlyJsonConverter` to support deserializing Kusto `datetime` values into C# `DateOnly` properties
  - Kusto has no native date-only type, so functions like `startofday()` and `bin(Timestamp, 1d)` return full `datetime` values (e.g. `2024-01-15T00:00:00Z`) — this converter enables mapping them to `DateOnly`
  - Registered in `KustoJsonSerializerOptions.Default`, covering both standard (`DataReaderExtensions`) and streaming (`DataRowExtensions`) deserialization paths