### PR TITLE
Fix code fix provider to use AddAdditionalDocument for kusto files

### DIFF
--- a/src/Atc.Kusto.Analyzer.CodeFixes/MissingKustoScriptResourceCodeFixProvider.cs
+++ b/src/Atc.Kusto.Analyzer.CodeFixes/MissingKustoScriptResourceCodeFixProvider.cs
@@ -72,8 +72,8 @@ public sealed class MissingKustoScriptResourceCodeFixProvider : CodeFixProvider
         // Create an empty .kusto file
         var kustoFileContent = string.Empty;
 
-        // Add the .kusto file to the project
-        var kustoDocument = document.Project.AddDocument(
+        // Add the .kusto file to the project as an additional document
+        var kustoDocument = document.Project.AddAdditionalDocument(
             expectedKustoFileName,
             Microsoft.CodeAnalysis.Text.SourceText.From(kustoFileContent, System.Text.Encoding.UTF8),
             folders: null,


### PR DESCRIPTION
The `MissingKustoScriptResourceCodeFixProvider` was incorrectly using `AddDocument` to create `.kusto` files, which adds them as regular C# documents instead of additional files. This fix switches to `AddAdditionalDocument`, which correctly registers them as additional files — matching how `.kusto` files are referenced via `<AdditionalFiles>` in the project and consumed by the Roslyn analyzer.

### :bug: Fixes
- Use `AddAdditionalDocument` instead of `AddDocument` in `MissingKustoScriptResourceCodeFixProvider` so generated `.kusto` files are properly registered as additional
  documents