### PR TITLE
Add TSV output format and human-friendly value formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ atc-kusto query "StormEvents | take 5" --tenant-id <GUID>
 atc-kusto query "StormEvents | summarize Count=count() by State | top 10 by Count desc" \
   --tenant-id <GUID> --format csv > top-states.csv
 
+# Output as TSV and redirect to a file
+atc-kusto query "StormEvents | summarize Count=count() by State | top 10 by Count desc" \
+  --tenant-id <GUID> --format tsv > top-states.tsv
+
 # Run a query from a file
 atc-kusto query --file myquery.kql --tenant-id <GUID>
 
@@ -191,7 +195,7 @@ echo "StormEvents | count" | atc-kusto query - --tenant-id <GUID> --cluster prod
 |--------|-------------|
 | `[QUERY]` | Inline KQL query text, or `-` to read from stdin |
 | `--file\|-f <PATH>` | Read query from a file (supports `:start-end` line range) |
-| `--format <FORMAT>` | Output format: `human`, `json`, `markdown` (or `md`), `csv` (default: `human`) |
+| `--format <FORMAT>` | Output format: `human`, `json`, `markdown` (or `md`), `csv`, `tsv` (default: `human`) |
 | `--show-stats` | Include query execution statistics in output |
 
 #### Output Formats
@@ -202,6 +206,7 @@ echo "StormEvents | count" | atc-kusto query - --tenant-id <GUID> --cluster prod
 | `json` | JSON array for scripting and automation |
 | `markdown` | GitHub Flavored Markdown table (`md` is accepted as an alias) |
 | `csv` | Comma-separated values (RFC 4180 quoting) |
+| `tsv` | Tab-separated values |
 
 ```bash
 # JSON output for scripting
@@ -212,6 +217,9 @@ atc-kusto query "StormEvents | take 5" --format markdown --tenant-id <GUID>
 
 # CSV output redirected to file
 atc-kusto query "StormEvents | take 5" --format csv --tenant-id <GUID> > results.csv
+
+# TSV output redirected to file
+atc-kusto query "StormEvents | take 5" --format tsv --tenant-id <GUID> > results.tsv
 ```
 
 #### Query Validation
@@ -226,7 +234,7 @@ Use `--show-stats` to display execution statistics after query results. Statisti
 atc-kusto query "StormEvents | count" --show-stats --tenant-id <GUID>
 ```
 
-> Note: `--show-stats` cannot be used with `--format csv`.
+> Note: `--show-stats` cannot be used with `--format csv` or `--format tsv`.
 
 #### Web Explorer Link
 

--- a/src/Atc.Kusto.CLI/Commands/Settings/QueryCommandSettings.cs
+++ b/src/Atc.Kusto.CLI/Commands/Settings/QueryCommandSettings.cs
@@ -14,7 +14,7 @@ public class QueryCommandSettings : DatabaseCommandSettings
     public string? FilePath { get; init; }
 
     [CommandOption("--format <FORMAT>")]
-    [Description("Output format: human, json, markdown, or csv (default: human)")]
+    [Description("Output format: human, json, markdown, csv, or tsv (default: human)")]
     public string Format { get; init; } = "human";
 
     [CommandOption("--show-stats")]
@@ -55,14 +55,14 @@ public class QueryCommandSettings : DatabaseCommandSettings
             }
         }
 
-        if (Format is not "human" and not "json" and not "markdown" and not "md" and not "csv")
+        if (Format is not "human" and not "json" and not "markdown" and not "md" and not "csv" and not "tsv")
         {
-            return ValidationResult.Error("--format must be one of: human, json, markdown, csv.");
+            return ValidationResult.Error("--format must be one of: human, json, markdown, csv, tsv.");
         }
 
-        if (ShowStats && Format is "csv")
+        if (ShowStats && Format is "csv" or "tsv")
         {
-            return ValidationResult.Error("--show-stats cannot be used with --format csv.");
+            return ValidationResult.Error($"--show-stats cannot be used with --format {Format}.");
         }
 
         return ValidationResult.Success();

--- a/src/Atc.Kusto.CLI/Extensions/CommandAppExtensions.cs
+++ b/src/Atc.Kusto.CLI/Extensions/CommandAppExtensions.cs
@@ -61,7 +61,8 @@ public static class CommandAppExtensions
             .WithExample("query", "--file", "myquery.kql", "--tenant-id", "<GUID>", "--cluster", "mycluster", "--database", "MyDb")
             .WithExample("query", "--file", "myquery.kql:5-10", "--tenant-id", "<GUID>", "--cluster", "mycluster", "--database", "MyDb")
             .WithExample("query", "\"StormEvents | take 5\"", "--tenant-id", "<GUID>", "--cluster", "mycluster", "--database", "MyDb", "--format", "json")
-            .WithExample("query", "\"StormEvents | take 5\"", "--tenant-id", "<GUID>", "--cluster", "mycluster", "--database", "MyDb", "--format", "csv");
+            .WithExample("query", "\"StormEvents | take 5\"", "--tenant-id", "<GUID>", "--cluster", "mycluster", "--database", "MyDb", "--format", "csv")
+            .WithExample("query", "\"StormEvents | take 5\"", "--tenant-id", "<GUID>", "--cluster", "mycluster", "--database", "MyDb", "--format", "tsv");
     }
 
     private static void ConfigureClusterCommands(

--- a/src/Atc.Kusto.CLI/Rendering/CsvResultRenderer.cs
+++ b/src/Atc.Kusto.CLI/Rendering/CsvResultRenderer.cs
@@ -3,8 +3,27 @@ namespace Atc.Kusto.CLI.Rendering;
 /// <summary>
 /// Renders results as comma-separated values (CSV) with RFC 4180 quoting.
 /// </summary>
-public sealed class CsvResultRenderer : IResultRenderer
+public class CsvResultRenderer : IResultRenderer
 {
+    private readonly char delimiter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CsvResultRenderer"/> class using comma as delimiter.
+    /// </summary>
+    public CsvResultRenderer()
+        : this(',')
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CsvResultRenderer"/> class.
+    /// </summary>
+    /// <param name="delimiter">The field delimiter character.</param>
+    protected CsvResultRenderer(char delimiter)
+    {
+        this.delimiter = delimiter;
+    }
+
     /// <inheritdoc />
     public void Render(
         IReadOnlyList<string> columns,
@@ -20,7 +39,7 @@ public sealed class CsvResultRenderer : IResultRenderer
         {
             if (i > 0)
             {
-                sb.Append(',');
+                sb.Append(delimiter);
             }
 
             sb.Append(EscapeField(columns[i]));
@@ -35,7 +54,7 @@ public sealed class CsvResultRenderer : IResultRenderer
             {
                 if (i > 0)
                 {
-                    sb.Append(',');
+                    sb.Append(delimiter);
                 }
 
                 sb.Append(EscapeField(row[i]));
@@ -54,11 +73,11 @@ public sealed class CsvResultRenderer : IResultRenderer
 
         var sb = new StringBuilder();
         sb.AppendLine();
-        sb.AppendLine("Statistic,Value");
+        sb.Append("Statistic").Append(delimiter).AppendLine("Value");
         foreach (var kvp in statistics)
         {
             sb.Append(EscapeField(kvp.Key))
-                .Append(',')
+                .Append(delimiter)
                 .AppendLine(EscapeField(kvp.Value));
         }
 
@@ -68,13 +87,13 @@ public sealed class CsvResultRenderer : IResultRenderer
     /// <inheritdoc />
     public void RenderWebExplorerUrl(Uri url)
     {
-        // CSV output omits non-tabular metadata
+        // Delimited output omits non-tabular metadata
     }
 
-    private static string EscapeField(string value)
+    private string EscapeField(string value)
     {
         if (value.Contains('"', StringComparison.Ordinal) ||
-            value.Contains(',', StringComparison.Ordinal) ||
+            value.Contains(delimiter, StringComparison.Ordinal) ||
             value.Contains('\n', StringComparison.Ordinal) ||
             value.Contains('\r', StringComparison.Ordinal))
         {

--- a/src/Atc.Kusto.CLI/Rendering/DisplayValueFormatter.cs
+++ b/src/Atc.Kusto.CLI/Rendering/DisplayValueFormatter.cs
@@ -1,0 +1,80 @@
+namespace Atc.Kusto.CLI.Rendering;
+
+/// <summary>
+/// Formats cell values for human-readable display: thousand separators for numbers,
+/// smart datetime formatting, and preservation of zero-padded identifiers.
+/// </summary>
+internal static class DisplayValueFormatter
+{
+    public static string FormatCellValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value ?? string.Empty;
+        }
+
+        // Skip zero-padded values that are likely identifiers (e.g., "001234")
+        var numericStart = value[0] == '-' ? 1 : 0;
+        if (value.Length > numericStart + 1 &&
+            value[numericStart] == '0' &&
+            char.IsDigit(value[numericStart + 1]))
+        {
+            return value;
+        }
+
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
+        {
+            return longValue.ToString("N0", CultureInfo.InvariantCulture);
+        }
+
+        if (decimal.TryParse(
+                value,
+                NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+                CultureInfo.InvariantCulture,
+                out var decimalValue))
+        {
+            var dotIndex = value.IndexOf('.', StringComparison.Ordinal);
+            if (dotIndex >= 0)
+            {
+                var decimalPlaces = value.Length - dotIndex - 1;
+                return decimalValue.ToString($"N{decimalPlaces}", CultureInfo.InvariantCulture);
+            }
+
+            return decimalValue.ToString("N0", CultureInfo.InvariantCulture);
+        }
+
+        // Format ISO 8601 datetime strings (YYYY-MM-DDTHH:mm:ss...)
+        if (value.Length >= 20 &&
+            char.IsDigit(value[0]) &&
+            value[4] == '-' &&
+            value[7] == '-' &&
+            value[10] == 'T' &&
+            DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
+        {
+            if (dateTimeValue.TimeOfDay == TimeSpan.Zero)
+            {
+                return dateTimeValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            }
+
+            // Non-midnight: replace T with space for readability, preserving timezone
+            return string.Concat(value.AsSpan(0, 10), " ", value.AsSpan(11));
+        }
+
+        return value;
+    }
+
+    public static bool IsNumericValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _) ||
+               decimal.TryParse(
+                   value,
+                   NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+                   CultureInfo.InvariantCulture,
+                   out _);
+    }
+}

--- a/src/Atc.Kusto.CLI/Rendering/HumanResultRenderer.cs
+++ b/src/Atc.Kusto.CLI/Rendering/HumanResultRenderer.cs
@@ -13,12 +13,21 @@ public sealed class HumanResultRenderer : IResultRenderer
         ArgumentNullException.ThrowIfNull(columns);
         ArgumentNullException.ThrowIfNull(rows);
 
+        // Detect numeric columns from raw data before formatting
+        var rightAligned = DetectNumericColumns(columns.Count, rows);
+
         var table = new Table();
         table.Border(TableBorder.Rounded);
 
-        foreach (var column in columns)
+        for (var i = 0; i < columns.Count; i++)
         {
-            table.AddColumn(new TableColumn(Markup.Escape(column)).NoWrap());
+            var col = new TableColumn(Markup.Escape(columns[i])).NoWrap();
+            if (rightAligned[i])
+            {
+                col.RightAligned();
+            }
+
+            table.AddColumn(col);
         }
 
         foreach (var row in rows)
@@ -26,7 +35,7 @@ public sealed class HumanResultRenderer : IResultRenderer
             var renderedCells = new string[row.Length];
             for (var i = 0; i < row.Length; i++)
             {
-                renderedCells[i] = Markup.Escape(row[i]);
+                renderedCells[i] = Markup.Escape(DisplayValueFormatter.FormatCellValue(row[i]));
             }
 
             table.AddRow(renderedCells);
@@ -62,5 +71,38 @@ public sealed class HumanResultRenderer : IResultRenderer
 
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine($"[link={Markup.Escape(url.AbsoluteUri)}]Open in Web Explorer[/]");
+    }
+
+    private static bool[] DetectNumericColumns(
+        int columnCount,
+        IReadOnlyList<string[]> rows)
+    {
+        var result = new bool[columnCount];
+        if (rows.Count == 0)
+        {
+            return result;
+        }
+
+        for (var i = 0; i < columnCount; i++)
+        {
+            var allNumeric = true;
+            foreach (var row in rows)
+            {
+                if (i >= row.Length || string.IsNullOrEmpty(row[i]))
+                {
+                    continue;
+                }
+
+                if (!DisplayValueFormatter.IsNumericValue(row[i]))
+                {
+                    allNumeric = false;
+                    break;
+                }
+            }
+
+            result[i] = allNumeric;
+        }
+
+        return result;
     }
 }

--- a/src/Atc.Kusto.CLI/Rendering/OutputFormat.cs
+++ b/src/Atc.Kusto.CLI/Rendering/OutputFormat.cs
@@ -24,4 +24,9 @@ public enum OutputFormat
     /// Comma-separated values output.
     /// </summary>
     Csv,
+
+    /// <summary>
+    /// Tab-separated values output.
+    /// </summary>
+    Tsv,
 }

--- a/src/Atc.Kusto.CLI/Rendering/OutputFormatParser.cs
+++ b/src/Atc.Kusto.CLI/Rendering/OutputFormatParser.cs
@@ -19,6 +19,7 @@ public static class OutputFormatParser
             "json" => OutputFormat.Json,
             "markdown" or "md" => OutputFormat.Markdown,
             "csv" => OutputFormat.Csv,
+            "tsv" => OutputFormat.Tsv,
             _ => OutputFormat.Human,
         };
     }

--- a/src/Atc.Kusto.CLI/Rendering/ResultRendererFactory.cs
+++ b/src/Atc.Kusto.CLI/Rendering/ResultRendererFactory.cs
@@ -16,6 +16,7 @@ public static class ResultRendererFactory
             OutputFormat.Json => new JsonResultRenderer(),
             OutputFormat.Markdown => new MarkdownResultRenderer(),
             OutputFormat.Csv => new CsvResultRenderer(),
+            OutputFormat.Tsv => new TsvResultRenderer(),
             _ => new HumanResultRenderer(),
         };
 }

--- a/src/Atc.Kusto.CLI/Rendering/TsvResultRenderer.cs
+++ b/src/Atc.Kusto.CLI/Rendering/TsvResultRenderer.cs
@@ -1,0 +1,15 @@
+namespace Atc.Kusto.CLI.Rendering;
+
+/// <summary>
+/// Renders results as tab-separated values (TSV).
+/// </summary>
+public sealed class TsvResultRenderer : CsvResultRenderer
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TsvResultRenderer"/> class.
+    /// </summary>
+    public TsvResultRenderer()
+        : base('\t')
+    {
+    }
+}

--- a/test/Atc.Kusto.CLI.Tests/Rendering/DisplayValueFormatterTests.cs
+++ b/test/Atc.Kusto.CLI.Tests/Rendering/DisplayValueFormatterTests.cs
@@ -1,0 +1,92 @@
+namespace Atc.Kusto.CLI.Tests.Rendering;
+
+public sealed class DisplayValueFormatterTests
+{
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    public void FormatCellValue_NullOrEmpty_ReturnsEmpty(
+        string? input,
+        string expected)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("42", "42")]
+    [InlineData("1000", "1,000")]
+    [InlineData("66380993", "66,380,993")]
+    [InlineData("-1234567", "-1,234,567")]
+    [InlineData("0", "0")]
+    public void FormatCellValue_Integers_AddsThousandSeparators(
+        string input,
+        string expected)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("3.14", "3.14")]
+    [InlineData("1234.56", "1,234.56")]
+    [InlineData("-9876.543", "-9,876.543")]
+    [InlineData("1000000.1", "1,000,000.1")]
+    public void FormatCellValue_Decimals_AddsThousandSeparatorsAndPreservesDecimalPlaces(
+        string input,
+        string expected)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("001234")]
+    [InlineData("007")]
+    [InlineData("-001234")]
+    public void FormatCellValue_ZeroPadded_PreservedAsIdentifiers(string input)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData("2026-02-27T00:00:00Z", "2026-02-27")]
+    [InlineData("2026-02-27T00:00:00+00:00", "2026-02-27")]
+    public void FormatCellValue_MidnightDatetime_StripsTime(
+        string input,
+        string expected)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("2026-02-27T14:30:00Z", "2026-02-27 14:30:00Z")]
+    [InlineData("2026-02-27T14:30:00+05:00", "2026-02-27 14:30:00+05:00")]
+    [InlineData("2026-02-27T08:15:30.123Z", "2026-02-27 08:15:30.123Z")]
+    public void FormatCellValue_NonMidnightDatetime_ReplacesTWithSpace(
+        string input,
+        string expected)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("hello")]
+    [InlineData("some text with spaces")]
+    [InlineData("2026-02-27")]
+    public void FormatCellValue_NonNumericNonDatetime_ReturnedAsIs(string input)
+    {
+        DisplayValueFormatter.FormatCellValue(input).Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData("42", true)]
+    [InlineData("3.14", true)]
+    [InlineData("-100", true)]
+    [InlineData("hello", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsNumericValue_ReturnsExpected(
+        string? input,
+        bool expected)
+    {
+        DisplayValueFormatter.IsNumericValue(input).Should().Be(expected);
+    }
+}

--- a/test/Atc.Kusto.CLI.Tests/Rendering/OutputFormatParserTests.cs
+++ b/test/Atc.Kusto.CLI.Tests/Rendering/OutputFormatParserTests.cs
@@ -8,6 +8,7 @@ public sealed class OutputFormatParserTests
     [InlineData("markdown", OutputFormat.Markdown)]
     [InlineData("md", OutputFormat.Markdown)]
     [InlineData("csv", OutputFormat.Csv)]
+    [InlineData("tsv", OutputFormat.Tsv)]
     public void Parse_ValidFormat_ReturnsExpected(
         string input,
         OutputFormat expected)

--- a/test/Atc.Kusto.CLI.Tests/Rendering/TsvResultRendererTests.cs
+++ b/test/Atc.Kusto.CLI.Tests/Rendering/TsvResultRendererTests.cs
@@ -1,13 +1,13 @@
 namespace Atc.Kusto.CLI.Tests.Rendering;
 
 [Collection("ConsoleOutput")]
-public sealed class CsvResultRendererTests
+public sealed class TsvResultRendererTests
 {
     [Fact]
     public void Render_TableOutput_WritesHeadersAndRows()
     {
         // Arrange
-        var renderer = new CsvResultRenderer();
+        var renderer = new TsvResultRenderer();
         var columns = new List<string> { "Name", "Count" };
         var rows = new List<string[]>
         {
@@ -23,19 +23,19 @@ public sealed class CsvResultRendererTests
 
         // Assert
         var output = writer.ToString();
-        var expected = $"Name,Count{Environment.NewLine}alpha,42{Environment.NewLine}beta,7{Environment.NewLine}";
+        var expected = $"Name\tCount{Environment.NewLine}alpha\t42{Environment.NewLine}beta\t7{Environment.NewLine}";
         output.Should().Be(expected);
     }
 
     [Fact]
-    public void Render_EscapesSpecialCharacters()
+    public void Render_EscapesTabsInValues()
     {
         // Arrange
-        var renderer = new CsvResultRenderer();
-        var columns = new List<string> { "Name", "Notes", "Quote" };
+        var renderer = new TsvResultRenderer();
+        var columns = new List<string> { "Name", "Notes" };
         var rows = new List<string[]>
         {
-            new[] { "alpha,beta", $"line1{Environment.NewLine}line2", "he said \"hi\"" },
+            new[] { "alpha\tbeta", "simple" },
         };
 
         using var writer = new StringWriter();
@@ -46,15 +46,37 @@ public sealed class CsvResultRendererTests
 
         // Assert
         var output = writer.ToString();
-        output.Should().Contain("\"alpha,beta\"");
-        output.Should().Contain("\"he said \"\"hi\"\"\"");
+        output.Should().Contain("\"alpha\tbeta\"");
+    }
+
+    [Fact]
+    public void Render_DoesNotEscapeCommas()
+    {
+        // Arrange
+        var renderer = new TsvResultRenderer();
+        var columns = new List<string> { "Name" };
+        var rows = new List<string[]>
+        {
+            new[] { "alpha,beta" },
+        };
+
+        using var writer = new StringWriter();
+        System.Console.SetOut(writer);
+
+        // Act
+        renderer.Render(columns, rows);
+
+        // Assert
+        var output = writer.ToString();
+        output.Should().Contain("alpha,beta");
+        output.Should().NotContain("\"alpha,beta\"");
     }
 
     [Fact]
     public void Render_EmptyRows_WritesOnlyHeader()
     {
         // Arrange
-        var renderer = new CsvResultRenderer();
+        var renderer = new TsvResultRenderer();
         var columns = new List<string> { "Name" };
         var rows = new List<string[]>();
 
@@ -67,29 +89,5 @@ public sealed class CsvResultRendererTests
         // Assert
         var output = writer.ToString();
         output.Should().Be($"Name{Environment.NewLine}");
-    }
-
-    [Fact]
-    public void RenderStatistics_WritesStatisticCsv()
-    {
-        // Arrange
-        var renderer = new CsvResultRenderer();
-        var stats = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["ExecutionTimeSec"] = "1.23",
-            ["Cpu.Total"] = "00:00:01.5",
-        };
-
-        using var writer = new StringWriter();
-        System.Console.SetOut(writer);
-
-        // Act
-        renderer.RenderStatistics(stats);
-
-        // Assert
-        var output = writer.ToString();
-        output.Should().Contain("Statistic,Value");
-        output.Should().Contain("ExecutionTimeSec,1.23");
-        output.Should().Contain("Cpu.Total,00:00:01.5");
     }
 }


### PR DESCRIPTION
# Summary

  - Add TSV output format for tab-delimited query results
  - Add human-friendly value formatting (thousand separators, smart dates)
  - Fix test parallelism race condition on Console.SetOut

  # Changes

  ### :sparkles: Features
  - Add TSV (`--format tsv`) output for query results
  - Add thousand separators for numeric columns in human output
  - Add smart datetime formatting in human output
  - Right-align numeric columns in human table output

  ### :recycle: Refactoring
  - Refactor CsvResultRenderer to accept configurable delimiter
  - Add TsvResultRenderer as thin subclass of CsvResultRenderer
  - Extract DisplayValueFormatter for reusable formatting logic

  ### :bug: Fixes
  - Add [Collection("ConsoleOutput")] to fix Console.SetOut race
  - Make --show-stats error message dynamic for csv/tsv formats

  ### :memo: Documentation
  - Add TSV examples to README quick start and format sections
  - Update format option descriptions to include tsv
  - Update --show-stats note to mention tsv restriction