### PR TITLE
Reserve resource path for ADE/ADX proxy cluster URLs

### DIFF
--- a/src/Atc.Kusto.CLI/Services/ClusterUtilities.cs
+++ b/src/Atc.Kusto.CLI/Services/ClusterUtilities.cs
@@ -5,8 +5,71 @@ namespace Atc.Kusto.CLI.Services;
 /// </summary>
 public static class ClusterUtilities
 {
+    // Fixed Kusto hostnames that front ADX as a proxy (ADE / Azure Monitor / Aria /
+    // security platform). Unlike classic ADX clusters (e.g., *.kusto.windows.net),
+    // a request to these hosts may carry a workspace- or resource-specific path that
+    // MUST be preserved end-to-end; collapsing to the bare hostname causes the proxy
+    // to reject the request (e.g., InvalidClusterHostName from prod-adxproxy) and
+    // makes it impossible to distinguish two workspaces on the same host.
+    //
+    // Source: the AllowedKustoHostnames entries in the public well-known Kusto
+    // endpoints list shipped with the official Azure Data Explorer SDKs.
+    private static readonly HashSet<string> ProxyHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Public cloud (login.microsoftonline.com)
+        "ade.applicationinsights.io",
+        "ade.loganalytics.io",
+        "adx.aimon.applicationinsights.azure.com",
+        "adx.applicationinsights.azure.com",
+        "adx.int.applicationinsights.azure.com",
+        "adx.int.loganalytics.azure.com",
+        "adx.int.monitor.azure.com",
+        "adx.loganalytics.azure.com",
+        "adx.monitor.azure.com",
+        "kusto.aria.microsoft.com",
+        "eu.kusto.aria.microsoft.com",
+        "api.securityplatform.microsoft.com",
+
+        // US Government (Fairfax)
+        "adx.applicationinsights.azure.us",
+        "adx.loganalytics.azure.us",
+        "adx.monitor.azure.us",
+
+        // China (Mooncake)
+        "adx.applicationinsights.azure.cn",
+        "adx.loganalytics.azure.cn",
+        "adx.monitor.azure.cn",
+
+        // US Nat (EagleX)
+        "adx.applicationinsights.azure.eaglex.ic.gov",
+        "adx.loganalytics.azure.eaglex.ic.gov",
+        "adx.monitor.azure.eaglex.ic.gov",
+
+        // US Sec (scloud)
+        "adx.applicationinsights.azure.microsoft.scloud",
+        "adx.loganalytics.azure.microsoft.scloud",
+        "adx.monitor.azure.microsoft.scloud",
+
+        // France sovereign (Bleu)
+        "adx.applicationinsights.azure.fr",
+        "adx.loganalytics.azure.fr",
+        "adx.monitor.azure.fr",
+
+        // Germany sovereign (Delos)
+        "adx.applicationinsights.azure.de",
+        "adx.loganalytics.azure.de",
+        "adx.monitor.azure.de",
+
+        // Singapore sovereign (GovSG)
+        "adx.applicationinsights.azure.sg",
+        "adx.loganalytics.azure.sg",
+        "adx.monitor.azure.sg",
+    };
+
     /// <summary>
-    /// Normalizes a cluster URL to its base authority (scheme + host).
+    /// Normalizes a cluster URL for consistent storage and lookup.
+    /// Classic ADX clusters collapse to scheme+host; known proxy hosts
+    /// (ADE/ADX/Azure Monitor/etc.) preserve their resource path.
     /// </summary>
     /// <param name="url">The cluster URL string.</param>
     /// <returns>The normalized URL, or null if invalid.</returns>
@@ -23,7 +86,69 @@ public static class ClusterUtilities
             return null;
         }
 
+        if (IsProxyHost(uri.Host) && uri.AbsolutePath.Length > 1)
+        {
+            var builder = new UriBuilder(uri)
+            {
+                Query = string.Empty,
+                Fragment = string.Empty,
+            };
+
+            return builder.Uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        }
+
         return $"{uri.Scheme}://{uri.Host}";
+    }
+
+    /// <summary>
+    /// Returns true if the given host is a known Kusto proxy endpoint
+    /// (ADE, ADX proxy, Azure Monitor, Aria, security platform).
+    /// </summary>
+    /// <param name="host">The host name to check.</param>
+    public static bool IsProxyHost(string host) => ProxyHosts.Contains(host);
+
+    /// <summary>
+    /// Returns a config with every URL-bearing field re-normalized so in-memory
+    /// state stays consistent regardless of what was written to disk by older
+    /// versions or by hand. The same instance is returned; fields are mutated.
+    /// </summary>
+    /// <param name="config">The CLI configuration to normalize.</param>
+    /// <returns>The same instance, with normalized URLs.</returns>
+    public static KustoCliConfig NormalizeConfig(KustoCliConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!string.IsNullOrWhiteSpace(config.DefaultClusterUrl))
+        {
+            var normalized = NormalizeClusterUrl(config.DefaultClusterUrl);
+            if (normalized is not null)
+            {
+                config.DefaultClusterUrl = normalized;
+            }
+        }
+
+        foreach (var cluster in config.Clusters)
+        {
+            var normalized = NormalizeClusterUrl(cluster.Url);
+            if (normalized is not null)
+            {
+                cluster.Url = normalized;
+            }
+        }
+
+        if (config.DefaultDatabases.Count > 0)
+        {
+            var rebuilt = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in config.DefaultDatabases)
+            {
+                var key = NormalizeClusterUrl(pair.Key) ?? pair.Key;
+                rebuilt[key] = pair.Value;
+            }
+
+            config.DefaultDatabases = rebuilt;
+        }
+
+        return config;
     }
 
     /// <summary>
@@ -43,14 +168,12 @@ public static class ClusterUtilities
             return null;
         }
 
-        // Match by name (case-insensitive)
         var byName = config.Clusters.Find(x => string.Equals(x.Name, reference, StringComparison.OrdinalIgnoreCase));
         if (byName is not null)
         {
             return byName;
         }
 
-        // Match by normalized URL
         var normalizedRef = NormalizeClusterUrl(reference);
         if (normalizedRef is null)
         {

--- a/src/Atc.Kusto.CLI/Services/FileCliConfigStore.cs
+++ b/src/Atc.Kusto.CLI/Services/FileCliConfigStore.cs
@@ -41,8 +41,9 @@ public sealed class FileCliConfigStore : ICliConfigStore
         }
 
         var json = await File.ReadAllTextAsync(configPath, Encoding.UTF8, cancellationToken);
-        return JsonSerializer.Deserialize<KustoCliConfig>(json, SerializerOptions)
-               ?? new KustoCliConfig();
+        var config = JsonSerializer.Deserialize<KustoCliConfig>(json, SerializerOptions)
+                     ?? new KustoCliConfig();
+        return ClusterUtilities.NormalizeConfig(config);
     }
 
     /// <inheritdoc />
@@ -51,6 +52,8 @@ public sealed class FileCliConfigStore : ICliConfigStore
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(config);
+
+        ClusterUtilities.NormalizeConfig(config);
 
         var directory = Path.GetDirectoryName(configPath);
         if (directory is not null && !Directory.Exists(directory))

--- a/test/Atc.Kusto.CLI.Tests/Services/ClusterUtilitiesTests.cs
+++ b/test/Atc.Kusto.CLI.Tests/Services/ClusterUtilitiesTests.cs
@@ -1,0 +1,208 @@
+namespace Atc.Kusto.CLI.Tests.Services;
+
+public sealed class ClusterUtilitiesTests
+{
+    [Theory]
+    [InlineData("https://help.kusto.windows.net", "https://help.kusto.windows.net")]
+    [InlineData("https://help.kusto.windows.net/", "https://help.kusto.windows.net")]
+    [InlineData("https://help.kusto.windows.net/Samples", "https://help.kusto.windows.net")]
+    [InlineData("HTTPS://Help.Kusto.Windows.Net", "https://help.kusto.windows.net")]
+    public void NormalizeClusterUrl_ClassicAdxHost_ReturnsAuthorityOnly(
+        string input,
+        string expected)
+    {
+        ClusterUtilities.NormalizeClusterUrl(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://ade.applicationinsights.io/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws",
+        "https://ade.applicationinsights.io/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws")]
+    [InlineData(
+        "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/",
+        "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws")]
+    [InlineData(
+        "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws",
+        "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws")]
+    [InlineData(
+        "https://adx.applicationinsights.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app",
+        "https://adx.applicationinsights.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app")]
+    [InlineData(
+        "https://adx.monitor.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app",
+        "https://adx.monitor.azure.com/subscriptions/sub/resourcegroups/rg/providers/microsoft.insights/components/app")]
+    public void NormalizeClusterUrl_AdeProxyHost_PreservesResourcePath(
+        string input,
+        string expected)
+    {
+        ClusterUtilities.NormalizeClusterUrl(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_AdeProxyHost_StripsQueryAndFragment()
+    {
+        const string input = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws?foo=bar#frag";
+        const string expected = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+
+        ClusterUtilities.NormalizeClusterUrl(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_AdeProxyHostWithoutPath_ReturnsAuthorityOnly()
+    {
+        ClusterUtilities.NormalizeClusterUrl("https://ade.applicationinsights.io")
+            .Should().Be("https://ade.applicationinsights.io");
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_InvalidUrl_ReturnsNull()
+    {
+        ClusterUtilities.NormalizeClusterUrl("not-a-url").Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizeClusterUrl_Empty_ReturnsNull()
+    {
+        ClusterUtilities.NormalizeClusterUrl(string.Empty).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("ade.applicationinsights.io")]
+    [InlineData("ade.loganalytics.io")]
+    [InlineData("adx.aimon.applicationinsights.azure.com")]
+    [InlineData("adx.applicationinsights.azure.com")]
+    [InlineData("adx.int.applicationinsights.azure.com")]
+    [InlineData("adx.int.loganalytics.azure.com")]
+    [InlineData("adx.int.monitor.azure.com")]
+    [InlineData("adx.loganalytics.azure.com")]
+    [InlineData("adx.monitor.azure.com")]
+    [InlineData("kusto.aria.microsoft.com")]
+    [InlineData("eu.kusto.aria.microsoft.com")]
+    [InlineData("api.securityplatform.microsoft.com")]
+    [InlineData("adx.applicationinsights.azure.us")]
+    [InlineData("adx.loganalytics.azure.us")]
+    [InlineData("adx.monitor.azure.us")]
+    [InlineData("adx.applicationinsights.azure.cn")]
+    [InlineData("adx.loganalytics.azure.cn")]
+    [InlineData("adx.monitor.azure.cn")]
+    [InlineData("adx.applicationinsights.azure.eaglex.ic.gov")]
+    [InlineData("adx.loganalytics.azure.eaglex.ic.gov")]
+    [InlineData("adx.monitor.azure.eaglex.ic.gov")]
+    [InlineData("adx.applicationinsights.azure.microsoft.scloud")]
+    [InlineData("adx.loganalytics.azure.microsoft.scloud")]
+    [InlineData("adx.monitor.azure.microsoft.scloud")]
+    [InlineData("adx.applicationinsights.azure.fr")]
+    [InlineData("adx.loganalytics.azure.fr")]
+    [InlineData("adx.monitor.azure.fr")]
+    [InlineData("adx.applicationinsights.azure.de")]
+    [InlineData("adx.loganalytics.azure.de")]
+    [InlineData("adx.monitor.azure.de")]
+    [InlineData("adx.applicationinsights.azure.sg")]
+    [InlineData("adx.loganalytics.azure.sg")]
+    [InlineData("adx.monitor.azure.sg")]
+    public void NormalizeClusterUrl_AllKnownProxyHosts_PreservePath(string host)
+    {
+        var input = $"https://{host}/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+
+        ClusterUtilities.NormalizeClusterUrl(input).Should().Be(input);
+        ClusterUtilities.IsProxyHost(host).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsProxyHost_IsCaseInsensitive()
+    {
+        ClusterUtilities.IsProxyHost("ADE.ApplicationInsights.IO").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsProxyHost_ReturnsFalseForClassicAdxCluster()
+    {
+        ClusterUtilities.IsProxyHost("help.kusto.windows.net").Should().BeFalse();
+    }
+
+    [Fact]
+    public void FindCluster_MatchesAdeProxyUrlByNormalizedFullPath()
+    {
+        var config = new KustoCliConfig
+        {
+            Clusters =
+            [
+                new KnownCluster
+                {
+                    Name = "workspace-cluster",
+                    Url = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws",
+                },
+            ],
+        };
+
+        var match = ClusterUtilities.FindCluster(
+            config,
+            "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/");
+
+        match.Should().NotBeNull();
+        match!.Name.Should().Be("workspace-cluster");
+    }
+
+    [Fact]
+    public void FindCluster_DoesNotMatchDifferentWorkspaceOnSameProxyHost()
+    {
+        var config = new KustoCliConfig
+        {
+            Clusters =
+            [
+                new KnownCluster
+                {
+                    Name = "workspace-a",
+                    Url = "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/a",
+                },
+            ],
+        };
+
+        var match = ClusterUtilities.FindCluster(
+            config,
+            "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/b");
+
+        match.Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizeConfig_PreservesAdeProxyUrlsForSavedClustersAndDefaults()
+    {
+        const string adeUrl = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+        var config = new KustoCliConfig
+        {
+            DefaultClusterUrl = adeUrl + "/",
+            Clusters =
+            [
+                new KnownCluster { Name = "ws", Url = adeUrl + "/" },
+            ],
+            DefaultDatabases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [adeUrl + "/"] = "ws",
+            },
+        };
+
+        var normalized = ClusterUtilities.NormalizeConfig(config);
+
+        normalized.DefaultClusterUrl.Should().Be(adeUrl);
+        normalized.Clusters[0].Url.Should().Be(adeUrl);
+        normalized.DefaultDatabases.Should().ContainKey(adeUrl);
+    }
+
+    [Fact]
+    public void NormalizeConfig_CollapsesClassicClusterUrlToAuthority()
+    {
+        var config = new KustoCliConfig
+        {
+            DefaultClusterUrl = "https://help.kusto.windows.net/Samples",
+            Clusters =
+            [
+                new KnownCluster { Name = "help", Url = "https://help.kusto.windows.net/Samples" },
+            ],
+        };
+
+        var normalized = ClusterUtilities.NormalizeConfig(config);
+
+        normalized.DefaultClusterUrl.Should().Be("https://help.kusto.windows.net");
+        normalized.Clusters[0].Url.Should().Be("https://help.kusto.windows.net");
+    }
+}


### PR DESCRIPTION
# Summary

  - Make the CLI usable against Kusto-over-proxy endpoints
  - Stop collapsing ADE/ADX/Monitor URLs down to their bare host
  - Keep saved config internally consistent across upgrades

  # Changes

  ### :bug: Fixes
  - Recognize ADE, ADX proxy, Azure Monitor, Aria, and security
    platform hostnames when normalizing a cluster URL
  - Preserve the resource path for those hosts so Log Analytics
    and App Insights workspaces stay addressable
  - Keep workspaces on the same host distinct in DefaultDatabases
  - Cover public, US Gov, China, EagleX, scloud, Bleu, Delos,
    and GovSG clouds

  ### :sparkles: Features
  - Add IsProxyHost helper for callers that need to branch on
    classic-vs-proxy cluster hostnames
  - Add NormalizeConfig helper that re-normalizes
    DefaultClusterUrl, saved clusters, and DefaultDatabases keys

  ### :wrench: Configuration
  - Wire NormalizeConfig into FileCliConfigStore load and save
    so older or hand-edited config files get cleaned up