### PR TITLE
Correct CLI component name to atc-kusto-cli

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,7 @@
       "extra-files": ["Directory.Build.props"]
     },
     "src/Atc.Kusto.CLI": {
-      "component": "atc-kusto",
+      "component": "atc-kusto-cli",
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
       "pull-request-title-pattern": "chore(cli): release version ${version}",


### PR DESCRIPTION
  ### :wrench: Configuration
  - Set component to "atc-kusto-cli" for src/Atc.Kusto.CLI package
  - Next CLI release will tag as atc-kusto-cli@vX.Y.Z as intended

  # Notes

  - Mis-tagged release atc-kusto@v3.5.1 was deleted and recreated
    as atc-kusto-cli@v3.5.1 at the same commit SHA (91612e4)